### PR TITLE
bump http-proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5146,9 +5146,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dot-prop": "^5.2.0",
     "elliptic": "^6.5.3",
     "handlebars": "^4.7.6",
+    "http-proxy": "^1.18.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-router-dom": "^4.3.1",


### PR DESCRIPTION
# Description

Details
GHSA-6x33-pw7p-hmpq
high severity
Vulnerable versions: < 1.18.1
Patched version: 1.18.1


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
